### PR TITLE
fix indentation and typo in folder

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -19,18 +19,18 @@ Other interesting topics are:
 * [The tremor-script language](tremor-script/index.md)
 * [The tremor-query language](tremor-query/index.md)
 * Artefacts namely:
-  * [Onramps](artefacts/onramps.md)
-  * [Offramps](artefacts/offramps.md)
-  * [Codecs](artefacts/codecs.md)
-  * [Pre-](artefacts/preprocessors.md) and [Postprocessors](artefacts/postprocessors.md)
+    * [Onramps](artefacts/onramps.md)
+    * [Offramps](artefacts/offramps.md)
+    * [Codecs](artefacts/codecs.md)
+    * [Pre-](artefacts/preprocessors.md) and [Postprocessors](artefacts/postprocessors.md)
 * Operational information about
-  * [Monitoring](operations/monitoring.md)
-  * [Configuration](operations/configuration.md) and the [Configuration Walkthrough](operations/configuration-walkthrough.md)
-  * [The tremor CLI](operations/cli.md)
+    * [Monitoring](operations/monitoring.md)
+    * [Configuration](operations/configuration.md) and the [Configuration Walkthrough](operations/configuration-walkthrough.md)
+    * [The tremor CLI](operations/cli.md)
 * [The tremor API](api.md)
 * Development related information
-  * [Benchmarks](development/benchmarking.md)
-  * [A Quickstart Guide](development/quick-start.md)
-  * Nots about [Testing](development/testing.md) and [Debugging](development/debugging.md)
+    * [Benchmarks](development/benchmarking.md)
+    * [A Quickstart Guide](development/quick-start.md)
+    * Nots about [Testing](development/testing.md) and [Debugging](development/debugging.md)
 
-This is not an exhaustive list and for the curious it might be worth to explore the `docs` forlder on their own.
+This is not an exhaustive list and for the curious it might be worth to explore the `docs` folder on their own.


### PR DESCRIPTION
* change 2 spaces to 4 for nested lists
* fix typo in `folder` spelling

r? @darach